### PR TITLE
docs(networks): update x402 network reference to reflect relay-as-facilitator

### DIFF
--- a/src/content/docs/directory/index.mdx
+++ b/src/content/docs/directory/index.mdx
@@ -10,7 +10,7 @@ All AIBTC services follow the same pattern: **mainnet** on `aibtc.com`, **testne
 | Service | Mainnet | Testnet | Source |
 |---------|---------|---------|--------|
 | **x402 API** | [x402.aibtc.com](https://x402.aibtc.com) | [x402.aibtc.dev](https://x402.aibtc.dev) | [GitHub](https://github.com/aibtcdev/x402-api) |
-| **Sponsor Relay** | [x402-relay.aibtc.com](https://x402-relay.aibtc.com) | [x402-relay.aibtc.dev](https://x402-relay.aibtc.dev) | [GitHub](https://github.com/aibtcdev/x402-sponsor-relay) |
+| **Sponsor Relay (Facilitator)** | [x402-relay.aibtc.com](https://x402-relay.aibtc.com) | [x402-relay.aibtc.dev](https://x402-relay.aibtc.dev) | [GitHub](https://github.com/aibtcdev/x402-sponsor-relay) |
 
 ### x402 API Endpoints
 
@@ -22,10 +22,13 @@ All AIBTC services follow the same pattern: **mainnet** on `aibtc.com`, **testne
 
 ### Sponsor Relay Endpoints
 
+The relay serves as both sponsor (gasless transactions) and facilitator (x402 V2 settlement) for AIBTC services.
+
 | Path | Description |
 |------|-------------|
 | `/` | Health check |
 | `/docs` | OpenAPI documentation |
+| `/settle` | Facilitator-compatible V2 settlement |
 
 ## Ecosystem Services
 
@@ -34,7 +37,7 @@ All AIBTC services follow the same pattern: **mainnet** on `aibtc.com`, **testne
 | **STX402** | [stx402.com](https://stx402.com) | x402 endpoint registry ([/docs](https://stx402.com/docs), [/dashboard](https://stx402.com/dashboard)) |
 | **x402 Biwas** | [x402.biwas.xyz](https://x402.biwas.xyz) | AI-powered DeFi analytics ([/analytics](https://x402.biwas.xyz/analytics)) |
 | **StacksScan** | [scan.stacksx402.com](https://scan.stacksx402.com) | x402 ecosystem explorer |
-| **Facilitator** | [facilitator.stacksx402.com/health](https://facilitator.stacksx402.com/health) | Payment verification service |
+| **Facilitator (External)** | [facilitator.stacksx402.com/health](https://facilitator.stacksx402.com/health) | Payment verification for non-AIBTC services |
 
 ## Tools & SDKs
 

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -30,8 +30,8 @@ import { LinkCard, CardGrid } from '@astrojs/starlight/components';
 | Service | Mainnet | Testnet |
 |---------|---------|---------|
 | **x402 API** | [x402.aibtc.com](https://x402.aibtc.com) | [x402.aibtc.dev](https://x402.aibtc.dev) |
-| **Sponsor Relay** | [x402-relay.aibtc.com](https://x402-relay.aibtc.com) | [x402-relay.aibtc.dev](https://x402-relay.aibtc.dev) |
-| **Facilitator** | [facilitator.stacksx402.com](https://facilitator.stacksx402.com/health) | — |
+| **Sponsor Relay (Facilitator)** | [x402-relay.aibtc.com](https://x402-relay.aibtc.com) | [x402-relay.aibtc.dev](https://x402-relay.aibtc.dev) |
+| **Facilitator (External)** | [facilitator.stacksx402.com](https://facilitator.stacksx402.com/health) | — |
 
 ### SDKs
 

--- a/src/content/docs/reference/networks.md
+++ b/src/content/docs/reference/networks.md
@@ -25,14 +25,19 @@ All AIBTC services: **mainnet** on `aibtc.com`, **testnet** on `aibtc.dev`.
 | **Docs** | [/docs](https://x402.aibtc.com/docs) | [/docs](https://x402.aibtc.dev/docs) |
 | **Dashboard** | [/dashboard](https://x402.aibtc.com/dashboard) | [/dashboard](https://x402.aibtc.dev/dashboard) |
 
-### Sponsor Relay
+### Sponsor Relay (Facilitator)
+
+The AIBTC relay serves as both **sponsor** (gasless Stacks transactions) and **facilitator** (x402 settlement) for AIBTC services. The `/settle` endpoint provides facilitator-compatible V2 settlement, replacing the external facilitator for all AIBTC x402 infrastructure.
 
 | Endpoint | Mainnet | Testnet |
 |----------|---------|---------|
 | **Base** | `https://x402-relay.aibtc.com` | `https://x402-relay.aibtc.dev` |
 | **Docs** | [/docs](https://x402-relay.aibtc.com/docs) | [/docs](https://x402-relay.aibtc.dev/docs) |
+| **Settle** | `/settle` | `/settle` |
 
-### Facilitator
+### Facilitator (External)
+
+The external facilitator at `facilitator.stacksx402.com` remains available for non-AIBTC services. AIBTC services (`stx402`, `x402-api`, `landing-page`) now route settlement through the AIBTC relay above.
 
 | Endpoint | URL |
 |----------|-----|


### PR DESCRIPTION
Closes #11

## Summary

- Updates the **Sponsor Relay** section in `reference/networks.md` to reflect its new dual role as both sponsor and facilitator, following the merge of native settlement in [aibtcdev/x402-sponsor-relay#47](https://github.com/aibtcdev/x402-sponsor-relay/pull/47)
- Adds a `/settle` endpoint row to the relay table (facilitator-compatible V2 settlement)
- Renames the external facilitator section to **Facilitator (External)** with a note clarifying that AIBTC services now route settlement through the relay
- Propagates label updates to `index.mdx` and `directory/index.mdx` for consistency

## What changed

| File | Change |
|------|--------|
| `src/content/docs/reference/networks.md` | Section renamed, description paragraph added, `/settle` row added, external facilitator section clarified |
| `src/content/docs/index.mdx` | Quick-start table labels updated |
| `src/content/docs/directory/index.mdx` | Service label updated, `/settle` endpoint documented, ecosystem Facilitator description updated |

## Notes

This PR documents the architectural direction — the AIBTC relay now acts as the settlement facilitator for all AIBTC x402 infrastructure (`stx402`, `x402-api`, `landing-page`). The external `facilitator.stacksx402.com` remains referenced for non-AIBTC services. The `/settle` endpoint is documented ahead of full deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)